### PR TITLE
BUG: Set the `SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL` env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ ENV PATH="/opt/ants-2.3.4:$PATH"
 ENV TZ=America/Toronto
 ENV SETUPTOOLS_SCM_PRETEND_VERSION="0.1.0"
 
+# SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL required due to
+# some dependency listing "scikit-learn" as "sklearn" in its dependencies
+ENV SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True
+
 RUN apt-get update -qq && \
     apt-get install -y -q --no-install-recommends \
        ca-certificates \


### PR DESCRIPTION
Set the `SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL` environment variable to `True` as some dependency is listing `scikit-learn` as `sklearn` in its dependencies.

Fixes:
```
   × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [18 lines of output]
      The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
      rather than 'sklearn' for pip commands.
```

Raised in:
https://github.com/scil-vital/dockerfile_tractolearn/actions/runs/4115761168/jobs/7104909747#step:3:1639