### PR TITLE
ENH: Remove SETUPTOOLS_SCM_PRETEND_VERSION

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM nvidia/cuda:11.8.0-base-ubuntu20.04
 ENV ANTSPATH="/opt/ants-2.3.4/"
 ENV PATH="/opt/ants-2.3.4:$PATH"
 ENV TZ=America/Toronto
-ENV SETUPTOOLS_SCM_PRETEND_VERSION="0.1.0"
+# ENV SETUPTOOLS_SCM_PRETEND_VERSION="0.1.0"
 
 # SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL required due to
 # some dependency listing "scikit-learn" as "sklearn" in its dependencies


### PR DESCRIPTION
Remove the environment variable SETUPTOOLS_SCM_PRETEND_VERSION, that was first used to patch a LookupError with tractolearn and setuptools_scm