### PR TITLE
ENH: Install BLAS and LAPACK for Pyhon SPAMS in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -13,6 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Install BLAS and LAPACK for the SPAMS Python package
+      run: sudo apt-get -y install libblas-dev liblapack-dev
+
     - name: Check out repository
       uses: actions/checkout@v3
 


### PR DESCRIPTION
Install BLAS and LAPACK libraries for the Python `SPAMS` package.

Fixes:
```
AttributeError: module 'numpy.__config__' has no attribute 'blas_opt_info'
[end of output]

note: This error originates from a subprocess, and is likely not a problem with pip.
ERROR: Failed building wheel for python-spams

(...)
Failed to build python-spams
```

raised for example in:
https://github.com/scil-vital/dockerfile_tractolearn/actions/runs/4146603974/jobs/7172466933#step:3:1987

Documentation:
https://pypi.org/project/spams/